### PR TITLE
Update AWS Pentest Cloud - Resources.md

### DIFF
--- a/AWS/AWS Pentest Cloud - Resources.md
+++ b/AWS/AWS Pentest Cloud - Resources.md
@@ -139,7 +139,7 @@ https://github.com/andresriancho/enumerate-iam
  
 Sometimes it freezes after couple of API calls. Since AWS APIs are being updated continuously. We’ll need to manually synchronize APIs with this tool.  
 ```
-git clone https://github.com/aws/aws-sdk-js.git
+git clone --depth 1 https://github.com/aws/aws-sdk-js.git
 ```
 
 ```


### PR DESCRIPTION
No need to have the whole git history and that way cloning is faster.